### PR TITLE
Fix multiple favourites of the same product

### DIFF
--- a/src/components/ProductCard.js
+++ b/src/components/ProductCard.js
@@ -31,9 +31,10 @@ const ProductCard = props => {
         productFavouriteRef.current.classList.add("animate__fadeOutTopRight");
 
         setTimeout(() => {
-                
-            productFavouriteRef.current.classList.remove("animate__fadeOutTopRight");
-            productFavouriteRef.current.style.display = "none";
+            if (productCartRef.current) {
+                productFavouriteRef.current.classList.remove("animate__fadeOutTopRight");
+                productFavouriteRef.current.style.display = "none";
+            }
         }, 500);
     }
 

--- a/src/data/FavouritesStore.js
+++ b/src/data/FavouritesStore.js
@@ -7,6 +7,11 @@ export const FavouritesStore = new Store({
 });
 
 export const addToFavourites = (categorySlug, productID) => {
-
-    FavouritesStore.update(s => { s.product_ids = [ ...s.product_ids, `${ categorySlug }/${ parseInt(productID) }` ]; } );
+    FavouritesStore.update(s => {
+        if (s.product_ids.find(id => id === `${ categorySlug }/${ parseInt(productID) }`)) {
+            s.product_ids = s.product_ids.filter(id => id !== `${ categorySlug }/${ parseInt(productID) }`);
+        } else {
+            s.product_ids = [ ...s.product_ids, `${ categorySlug }/${ parseInt(productID) }` ];
+        }
+    });
 }

--- a/src/pages/FavouriteProducts.js
+++ b/src/pages/FavouriteProducts.js
@@ -21,6 +21,8 @@ const FavouriteProducts = () => {
 
         const getFavourites = () => {
 
+            setSearchResults([]);
+
             favourites.forEach(favourite => {
 
                 var favouriteParts = favourite.split("/");


### PR DESCRIPTION
Fixes Issue #1 

Allows for toggling favourited items instead of repeatedly adding them to the FavouritesStore. It also fixes a bug of multiplying items in the favourites screen